### PR TITLE
change default value to blank for no OU cert

### DIFF
--- a/autoinstall.d/data/rhui/4/rhua/60_rhua_install_rhui.sh
+++ b/autoinstall.d/data/rhui/4/rhua/60_rhua_install_rhui.sh
@@ -31,7 +31,7 @@ rhui_installer_options="\
 rhui-installer \
     ${rhui_installer_common_options} \
     ${rhui_installer_options:?} \
-    ${RHUI_INSTALLER_TLS_OPTIONS:?} \
+    "${RHUI_INSTALLER_TLS_OPTIONS[@]:?}" \
 | tee 2>&1 ${rhui_installer_log} && \
 touch ${rhui_installer_stamp}
 )

--- a/autoinstall.d/data/rhui/4/rhua/config.sh
+++ b/autoinstall.d/data/rhui/4/rhua/config.sh
@@ -74,7 +74,7 @@ RHUI_STORAGE_TYPE={{ rhui.storage.fstype }}
 RHUI_STORAGE_MOUNT={{ rhui.storage.server }}:{{ rhui.storage.mnt }}
 RHUI_STORAGE_MOUNT_OPTIONS="{{ rhui.storage.mnt_options|join(',')|default('rw') }}"
 
-RHUI_INSTALLER_TLS_OPTIONS=("--certs-country" "{{ rhui.tls.country|default('JP') }}" "--certs-state" "{{ rhui.tls.state|default('Tokyo') }}" "--certs-city" "{{ rhui.tls.city }}" "--certs-org" "{{ rhui.tls.org }}" "--certs-org-unit" "{{ rhui.tls.unit|default('Cloud') }}")
+RHUI_INSTALLER_TLS_OPTIONS=("--certs-country" "{{ rhui.tls.country|default('JP') }}" "--certs-state" "{{ rhui.tls.state|default('Tokyo') }}" "--certs-city" "{{ rhui.tls.city }}" "--certs-org" "{{ rhui.tls.org }}" "--certs-org-unit" "{{ rhui.tls.unit|default('') }}")
 {%- if proxy is defined and proxy.fqdn is defined %}
 RHUI_INSTALLER_TLS_OPTIONS="${RHUI_INSTALLER_TLS_OPTIONS:?} --proxy-protocol {{ proxy.protocol|default('http') }} --proxy-hostname {{ proxy.fqdn }} --proxy-port {{ proxy.port|default("443") }}"
 {%-    if proxy.user is defined %}

--- a/autoinstall.d/data/rhui/4/rhua/config.sh
+++ b/autoinstall.d/data/rhui/4/rhua/config.sh
@@ -74,7 +74,7 @@ RHUI_STORAGE_TYPE={{ rhui.storage.fstype }}
 RHUI_STORAGE_MOUNT={{ rhui.storage.server }}:{{ rhui.storage.mnt }}
 RHUI_STORAGE_MOUNT_OPTIONS="{{ rhui.storage.mnt_options|join(',')|default('rw') }}"
 
-RHUI_INSTALLER_TLS_OPTIONS="--certs-country {{ rhui.tls.country|default('JP') }} --certs-state {{ rhui.tls.state|default('Tokyo') }} --certs-city {{ rhui.tls.city }} --certs-org {{ rhui.tls.org }} --certs-org-unit {{ rhui.tls.unit|default('Cloud') }}"
+RHUI_INSTALLER_TLS_OPTIONS=("--certs-country" "{{ rhui.tls.country|default('JP') }}" "--certs-state" "{{ rhui.tls.state|default('Tokyo') }}" "--certs-city" "{{ rhui.tls.city }}" "--certs-org" "{{ rhui.tls.org }}" "--certs-org-unit" "{{ rhui.tls.unit|default('Cloud') }}")
 {%- if proxy is defined and proxy.fqdn is defined %}
 RHUI_INSTALLER_TLS_OPTIONS="${RHUI_INSTALLER_TLS_OPTIONS:?} --proxy-protocol {{ proxy.protocol|default('http') }} --proxy-hostname {{ proxy.fqdn }} --proxy-port {{ proxy.port|default("443") }}"
 {%-    if proxy.user is defined %}


### PR DESCRIPTION
see also 
https://www.cybertrust.co.jp/blog/ssl/regulations/ou-usage-prohibit.html

rhui-installer has default OU value.
If I want to create no OU cert, I need to specify blank value.
I think miniascape should use blank as default.