### PR TITLE
change nfs option

### DIFF
--- a/autoinstall.d/snippets/ks/post.rhui-4-nfs
+++ b/autoinstall.d/snippets/ks/post.rhui-4-nfs
@@ -2,7 +2,7 @@ nfs_name={{ exportfs.name }}
 nfs_dir={{ exportfs.dir }}
 f=/etc/exports.d/${nfs_name}.exports
 cat << EOF > $f
-${nfs_dir} {{ rhui.rhua.fqdn }}(rw,no_root_squash) {{ rhui.cds.servers[0].fqdn }}(ro,no_root_squash) {{ rhui.cds.servers[1].fqdn }}(ro,no_root_squash)
+${nfs_dir} {{ rhui.rhua.fqdn }}(rw,no_root_squash) {{ rhui.cds.servers[0].fqdn }}(rw,no_root_squash) {{ rhui.cds.servers[1].fqdn }}(rw,no_root_squash)
 EOF
 
 mkdir -p "${nfs_dir}"


### PR DESCRIPTION
Changed NFS option RO to RW for CDS.
Because rhui-installer set RW mount option to CDS.